### PR TITLE
ENH: Update llm class to llama index's OpenAI instead of langchains

### DIFF
--- a/app/chat/engine.py
+++ b/app/chat/engine.py
@@ -4,7 +4,8 @@ from typing import List
 
 import tiktoken
 from langchain.embeddings import XinferenceEmbeddings
-from langchain.llms import OpenAI, Xinference
+from langchain.llms import Xinference
+from llama_index.llms import OpenAI
 from llama_index import ServiceContext, VectorStoreIndex
 from llama_index.callbacks import LlamaDebugHandler
 from llama_index.callbacks.base import CallbackManager
@@ -26,7 +27,7 @@ from .constants import (
     NODE_PARSER_CHUNK_OVERLAP,
     NODE_PARSER_CHUNK_SIZE,
 )
-from .qa_response_synth import get_sys_prompt
+from .qa_response_synth import get_sys_prompt, get_context_prompt_template
 from .utils import fetch_and_read_documents
 
 logger = logging.getLogger(__name__)
@@ -134,6 +135,7 @@ def get_chat_engine(documents: List[DocumentSchema]) -> BaseChatEngine:
     chat_engine = index.as_chat_engine(
         chat_mode=ChatMode.CONTEXT,
         memory=memory,
+        context_template=get_context_prompt_template(documents),
         system_prompt=get_sys_prompt(),
     )
     return chat_engine

--- a/app/chat/qa_response_synth.py
+++ b/app/chat/qa_response_synth.py
@@ -1,3 +1,5 @@
+from typing import List
+
 from llama_index import PromptTemplate
 from llama_index.indices.service_context import ServiceContext
 from llama_index.prompts.prompt_type import PromptType
@@ -6,7 +8,7 @@ from llama_index.response_synthesizers import BaseSynthesizer
 from llama_index.response_synthesizers.factory import get_response_synthesizer
 
 from .utils import build_title_for_document
-
+from ..models.schema import Document as DocumentSchema
 
 def get_custom_response_synthesizer(
     service_context: ServiceContext, documents
@@ -50,36 +52,32 @@ def get_custom_response_synthesizer(
     )
 
 
-def get_template():
+def get_context_prompt_template(documents: List[DocumentSchema]):
+    doc_titles = "\n".join("- " + build_title_for_document(doc) for doc in documents)
     return PromptTemplate(
-        """
-Given a conversation (between Human and Assistant) and a follow up message from Human, \
-rewrite the message to be a standalone question that captures all relevant context \
-from the conversation.
-
-<Chat History>
-{chat_history}
-
-<Follow Up Message>
-{question}
-
-<Standalone question>
-""".strip()
+        "用户选择了一组文档，并询问了有关这些文件的问题。这些文件的标题如下: \n"
+        f"{doc_titles}"
+        "以下是上下文信息。\n"
+        "---------------------\n"
+        "{context_str}"
+        "\n---------------------\n"
     )
-
 
 def get_sys_prompt():
     return """
-你是一个基金公司的客服，你总是根据用户提供的文档用最相关的信息回答问题，文档中包含有关用户感兴趣的基金产品的信息。
+你是一个客服，你总是根据用户提供的文档用最相关的信息回答问题，文档中包含有关用户感兴趣的信息。
 
 以下是一些你必须遵循的准则:
 
-- 对于基金问题，你必须从用户提供的的文件找到答案，然后编写一个有用的回答。
+- 你必须从用户提供的的文件找到答案，然后编写一个有用的回答。
 - 即使提供的文件似乎无法回答问题，你仍然必须使用它们来找到最相关的信息和见解，不使用它们会让用户觉得你没有履行自己的职责。
 - 你可以假设用户提出的问题与提供的文件有关。
 - 如果你无法找到答案，你应该说你没有找到答案，仍然尽可能传递从文档中找到的有用信息。
+- 你无需告知用户回答中包含的信息来自于哪个文件。
 - 当用户询问任何与基金产品无关的信息时，礼貌地拒绝回应，并建议用户提出相关问题。
-- 但如果你发现用户不是在提问，而是对基金的表现进行抱怨或指责时，请进行情绪上的安抚。
+- 如果你发现用户不是在提问，而是在进行情绪上表达时，请进行安抚。
+- 请完整保留文件原文中的“img”标签，不要修改标签的结构，包括它们的src属性和任何其他属性，仍然以“img”标签返回。
+- 请完整保留文件原文中的“a”标签，请确保href属性被保留，并且链接文本保持不变。
 
 记住，你只扮演客服的角色，不要模拟客户的问题。你必须总是用中文回答问题。
 """

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,8 +10,8 @@ services:
     volumes:
       - ./app:/app/app
     environment:
-      - LLM=xinference
-      - EMBEDDING=xinference
+      - LLM=openai
+      - EMBEDDING=openai
       - XINFERENCE_SERVER_ENDPOINT=http://127.0.0.1:9997
       - XINFERENCE_EMBEDDING_MODEL_UID=20901038-79f7-11ee-8da3-047c1643e4f5
       - XINFERENCE_LLM_MODEL_UID=280557a6-79f7-11ee-8da3-047c1643e4f5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ fastapi = "^0.70.0"
 streamlit = "^1.27.0"
 uvicorn = "^0.15.0"
 pypdf = "^3.5.2"
-llama-index = "^0.8.51"
+llama-index = "^0.8.64"
 nltk = "^3.8.1"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
`langchain.llms.openai`调的是老版openai chat completion接口，把历史消息用Human和AI前缀标识，塞进一条消息里，导致补全的消息会以“AI：”开头。


<img width="1408" alt="image" src="https://github.com/xorbitsai/doc-insights/assets/977633/c593f013-2cde-4fca-8fab-735b13c18378">


新版行为是通过messages数组。

<img width="1407" alt="image" src="https://github.com/xorbitsai/doc-insights/assets/977633/e31e2a38-b3b0-401e-bc9c-d48232d57f77">
